### PR TITLE
Fixed syntax error

### DIFF
--- a/src/reverie/picker.py
+++ b/src/reverie/picker.py
@@ -646,7 +646,7 @@ class ConversationPicker:
                 days_diff = (now.date() - timestamp.date()).days
 
                 if days_diff == 0:
-                    updated_text = f"Today {timestamp.strftime("%H:%M")}"
+                    updated_text = f"Today {timestamp.strftime('%H:%M')}"
                 elif days_diff < 7:
                     updated_text = timestamp.strftime("%m/%d %H:%M")
                 else:


### PR DESCRIPTION
Thank you for this amazing tool! 🚀

This PR fixes a syntax error that happens on startup: 

```
➜  reverie git:(main) task run
task: [run] poetry run reverie
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/oliviertessier-lariviere/.pyenv/versions/3.11.10/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/oliviertessier-lariviere/code/tmp_dir/reverie/src/reverie/__main__.py", line 16, in <module>
    from .picker import pick_conversation
  File "/Users/oliviertessier-lariviere/code/tmp_dir/reverie/src/reverie/picker.py", line 649
    updated_text = f"Today {timestamp.strftime("%H:%M")}"
                                                ^
SyntaxError: f-string: unmatched '('
task: Failed to run task "run": exit status 1
```
